### PR TITLE
Remove mount point for VB additions when no longer required

### DIFF
--- a/tasks/virtualbox.yml
+++ b/tasks/virtualbox.yml
@@ -21,3 +21,8 @@
     src: "/home/vagrant/VBoxGuestAdditions_{{ virtualbox_version.stdout }}.iso"
     state: absent
     fstype: iso9660
+
+- name: Delete VirtualBox guest additions ISO.
+  file:
+    src: "/home/vagrant/VBoxGuestAdditions_{{ virtualbox_version.stdout }}.iso"
+    stage: absent

--- a/tasks/virtualbox.yml
+++ b/tasks/virtualbox.yml
@@ -19,5 +19,5 @@
   mount:
     name: /tmp/vbox
     src: "/home/vagrant/VBoxGuestAdditions_{{ virtualbox_version.stdout }}.iso"
-    state: unmounted
+    state: absent
     fstype: iso9660

--- a/tasks/vmware.yml
+++ b/tasks/vmware.yml
@@ -28,7 +28,7 @@
     name: /tmp/vmfusion
     src: /home/vagrant/linux.iso
     fstype: iso9660
-    state: unmounted
+    state: absent
 
 - name: Remove temporary directories for VMware tools.
   file:
@@ -37,3 +37,8 @@
   with_items:
     - vmfusion
     - vmfusion-archive
+
+- name: Delete VMWare Tools.
+  file:
+    src: /home/vagrant/linux.iso
+    stage: absent


### PR DESCRIPTION
Previously this was set to always mount the VirtualBox additions on each
boot, this creates a problem if the additions ISO has been removed, it
is common with Vagrant boxes that the user home directory be free of any
other files than those required. As these are no longer required after
the initial install these should be removed. The removal is not within
the scope of this project but we shouldn't be mounting this on each boot
and breaking the machine

This fixes https://github.com/geerlingguy/ansible-role-packer-debian/issues/5