### PR TITLE
Fix typo on unmount task

### DIFF
--- a/tasks/virtualbox.yml
+++ b/tasks/virtualbox.yml
@@ -24,5 +24,5 @@
 
 - name: Delete VirtualBox guest additions ISO.
   file:
-    src: "/home/vagrant/VBoxGuestAdditions_{{ virtualbox_version.stdout }}.iso"
-    stage: absent
+    path: "/home/vagrant/VBoxGuestAdditions_{{ virtualbox_version.stdout }}.iso"
+    state: absent

--- a/tasks/vmware.yml
+++ b/tasks/vmware.yml
@@ -40,5 +40,5 @@
 
 - name: Delete VMWare Tools.
   file:
-    src: /home/vagrant/linux.iso
-    stage: absent
+    path: /home/vagrant/linux.iso
+    state: absent


### PR DESCRIPTION
Sorry! This one was my bad, I just realised when testing it out this morning I've made a typo in the task so it's `stage` rather than `state`. This PR fixes that.

Tested this out during a box build on VirtualBox this morning.

Sorry again!!! :cry: 