### PR TITLE
Add task file updates.yml for updates of all packages

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,7 @@
 ---
-# TODO: Consider adding "upgrade=full" to also update everything.
+- include: updates.yml
+  when: with_updates | default('0') == "1"
+
 - name: Ensure apt cache is updated.
   apt: update_cache=yes cache_valid_time=3600
 

--- a/tasks/updates.yml
+++ b/tasks/updates.yml
@@ -1,0 +1,24 @@
+---
+- name: Ensure host is updated.
+  apt:
+    upgrade: dist
+    update_cache: yes
+    cache_valid_time: 3600
+
+- name: Check if reboot is required.
+  stat:
+    path: /var/run/reboot-required
+  register: reboot_required
+
+- name: Ensure host is rebooted after updates.
+  shell: sleep 2 && shutdown -r now "Ansible updates triggered"
+  async: 0
+  poll: 0
+  ignore_errors: true
+  register: is_rebooted
+  when: reboot_required.stat.exists
+
+- name: Waiting for host to come back.
+  local_action: wait_for port="{{ ansible_port }}" host="{{ ansible_host }}" delay=45
+  become: false
+  when: is_rebooted | changed


### PR DESCRIPTION
Also add condition to include updates.yml task file only if `with_updates` variable is equal to "1".

Add fall back to `0` if variable is undefined. `with_updates` variable can be passed to extra_arguments array of ansible packer provisioner. Considerer example:
```json
{
          "type": "ansible",
          "playbook_file": "ansible/playbook.yml",
          "ansible_env_vars":[
            "ANSIBLE_NOCOWS=True",
            "ANSIBLE_RETRY_FILES_ENABLED=False"
          ],
          "extra_arguments": [
            "--extra-vars", "with_updates={{ user `with_updates` }}"
          ]
   }
],
  "variables": {
   "with_updates":"0"
  }
```
or passing by command line
```bash
packer build -var='with_updates=1' ubuntu-14.04-amd64.json
```