### PR TITLE
Make removal of unneeded packages configurable and enabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,11 @@ If you'd like to add additional roles, make sure you add them to the `role_paths
 Available variables are listed below, along with default values (see defaults/main.yml):
 
     vmware_install_open_vm_tools: no
+    remove_unneeded_packages: yes
 
 (VMware only) Using the `vmware_install_open_vm_tools` variable, you can select what kind of integration components will be installed into the VMware box. The default (`no`) installs VMware Tools, and not `open-vm-tools`.
+
+Using the `remove_unneeded_packages` variable, you can select whether commonly unneeded packages should be removed. The default (`yes`) removes the packages. Set to `no` if removing any of the packages will cause issues with your VM. See `tasks/main.yml` for the list of packages that are removed.
 
 Read more:
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 vmware_install_open_vm_tools: no
+remove_unneeded_packages: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -72,6 +72,7 @@
       - libxext6
       - linux-source
     state: absent
+  when: remove_unneeded_packages
 
 - name: Remove unneeded packages (by regex).
   shell: "apt-get -y remove '.*-dev$'"


### PR DESCRIPTION
Thanks for the great work on this role and all the other ones you've put out. Its nice to see and learn how to properly create Ansible roles.

When applying the Ansible role, the “Remove unneeded packages.” task removes some packages that my system needs. I recommend making the task configurable but enabled by default. This will allow the task to be skipped if it breaks something in an install. I tested the fix via the suggested change and it works to preserve the functionality of my image (which includes a GUI).