### PR TITLE
Do not detect a KVM VM as VMWare

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,7 +46,7 @@
 
 # VMware tools installation.
 - name: Check if VMWare is running the guest VM.
-  shell: "dmesg | grep VMware | wc -l"
+  shell: "dmesg | grep VMware | grep -v VMMouse | wc -l"
   changed_when: false
   failed_when: false
   register: vmware_check


### PR DESCRIPTION
When this role is applied in a KVM VM (for example vagrant-libvirt) the role detects it as a VMWare VM because it uses "VMMouse" from VMWare. This should make the check better.